### PR TITLE
Dev/messages help block

### DIFF
--- a/app/templates/complexForm.html
+++ b/app/templates/complexForm.html
@@ -3,7 +3,7 @@
   <fieldset>
     <legend>Personal information</legend>
 
-    <div af-messages="user.personalinfo"></div>
+    <div af-messages="user.personalinfo" af-alert></div>
 
     <div class="form-group" af-field-state af-feedback af-field-name="user.name">
       <label class="control-label col-md-2" for="name">Name*</label>

--- a/app/templates/simpleForm.html
+++ b/app/templates/simpleForm.html
@@ -1,7 +1,7 @@
 <h2>Simple form</h2>
 <form class="form-horizontal" af-submit="afterSubmit()" name="userForm" novalidate>
 
-  <div af-messages></div>
+  <div af-messages af-alert></div>
 
   <fieldset>
     <legend>Personal information</legend>
@@ -44,7 +44,7 @@
             I agree
           </label>
         </div>
-        <div af-message="user.agree"></div>
+        <div af-messages="user.agree"></div>
       </div>
       <div class="col-md-6"><pre ng-show="user.agree">{{user.agree}}</pre></div>
     </div>

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-form-messages-example",
+  "main": "app.js",
   "version": "0.11.0",
   "dependencies": {
     "angular": "1.4",


### PR DESCRIPTION
Show the messages on the fields as help-blocks so that they do not interfere with af-field-state and show the aggregated messages as alert.
